### PR TITLE
add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# d_adw
+
+Auto generated LibAdwaita bindings from the GIR API description using [girtod](https://code.dlang.org/packages/girtod).
+
+To use this you need to use GtkD with GTK 4, which at the time of writing is not released to DUB yet.
+
+To use GtkD with GTK 4 replace the gtk dependency or add it to your dub.json:
+
+```json
+"dependencies": {
+	"gtk-d": {
+		"repository": "git+https://github.com/gtkd-developers/GtkD.git",
+		"version": "73b54335652b1712a569af81a02661b35d211244"
+	}
+}
+```
+
+or dub.sdl:
+
+```sdl
+dependency "gtk-d" repository="git+https://github.com/gtkd-developers/GtkD.git" version="73b54335652b1712a569af81a02661b35d211244"
+```
+
+Which pins GtkD to the specified commit. You can check for the latest commit on https://github.com/gtkd-developers/GtkD/tree/gtk4
+
+Then to use d_adw, add it as git submodule or clone it into your project folder and add it as DUB dependency:
+
+```json
+"dependencies": {
+	"d_adw": { "path": "d_adw" }
+}
+```
+
+or dub.sdl:
+
+```
+dependency "d_adw" path="d_adw"
+```

--- a/examples/avatar/dub.json
+++ b/examples/avatar/dub.json
@@ -3,7 +3,11 @@
 		"KonstantIMP"
 	],
 	"dependencies": {
-		"d_adw" : "*"
+		"d_adw" : { "path": "../.." },
+		"gtk-d": {
+			"repository": "git+https://github.com/gtkd-developers/GtkD.git",
+			"version": "73b54335652b1712a569af81a02661b35d211244"
+		}
 	},
 	"copyright": "Copyright © 2021, KonstantIMP",
 	"description": "Example of using AdwaitaAvatar widget with gtk4",

--- a/examples/avatar/dub.selections.json
+++ b/examples/avatar/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"d_adw": "0.0.1",
-		"gtk-d": "4.0.0"
+		"d_adw": {"path":"../.."},
+		"gtk-d": {"version":"73b54335652b1712a569af81a02661b35d211244","repository":"git+https://github.com/gtkd-developers/GtkD.git"}
 	}
 }


### PR DESCRIPTION
depends on #2 because of dub.json change, but could be included as-is already.

This says in the README to clone/submodule this repository as it's not published to the DUB registry and may make more sense to pin to specific commits implementing the wanted LibAdwaita version.

Updates the example dub.json to work by just running `dub upgrade` / `dub` without needing to add-local or any other stuff.